### PR TITLE
added rotate_axis

### DIFF
--- a/bench/matrix4x4.c3
+++ b/bench/matrix4x4.c3
@@ -190,6 +190,10 @@ fn void rotate_z()
 {
 	mat4x4_1.rotate_z(math::PI);
 }
+fn void rotate_axis()
+{
+	mat4x4_1.rotate_axis(math::PI, v3);
+}
 fn void transpose_assign()
 {
 	matrix::transpose_assign(&m4, &mat4x4_1);

--- a/src/matrix.c3
+++ b/src/matrix.c3
@@ -865,6 +865,15 @@ macro Matrix.rotate_y(&self, double theta) => *self = matrix::rotated_y(theta, T
  @require ROWS >= 3 : "Cannot apply 3D rotation to matrix less than 3x3"
  *>
 macro Matrix.rotate_z(&self, double theta) => *self = matrix::rotated_z(theta, Type, ROWS).mul(*self);
+<*
+ Applies a 3D rotation about an arbitrary axis using Rodrigues' rotation formula
+
+ @param theta : "Rotation angle in radians"
+ @param rotate_vec : "Rotation axis"
+ @require ROWS == COLS : "Cannot apply 3D axis rotation to non-square matrix"
+ @require ROWS >= 3 : "Cannot apply 3D axis rotation to matrix less than 3x3"
+ *>
+macro Matrix.rotate_axis(&self, double theta, rotate_vec) => *self = matrix::rotated_axis(theta, rotate_vec, Type, ROWS).mul(*self);
 
 module c3math::matrix;
 

--- a/src/matrix_initializers.c3
+++ b/src/matrix_initializers.c3
@@ -117,6 +117,36 @@ macro rotated_z(double theta, $Type = double, $size = 3)
 	return result;
 	$endif
 }
+<*
+ @param $size : "Size of matrix (default: 3)"
+ @param $Type : "Type of matrix (default: double)"
+ @return "3D axis rotation matrix of specified size"
+ *>
+macro rotated_axis(double theta, rotate_vec, $Type = double, $size = 3)
+{
+	double len = math::sqrt(rotate_vec[0]*rotate_vec[0] + rotate_vec[1]*rotate_vec[1] + rotate_vec[2]*rotate_vec[2]);
+	double x = rotate_vec[0] / len;
+	double y = rotate_vec[1] / len;
+	double z = rotate_vec[2] / len;
+
+	double s = math::sin(theta);
+	double c = math::cos(theta);
+	double k = 1.0 - c;
+
+	Matrix{3,3, $Type} r = {{
+		[0] = x*x*k + c,    [3] = x*y*k + z*s,  [6] = x*z*k - y*s,
+		[1] = y*x*k - z*s,  [4] = y*y*k + c,    [7] = y*z*k + x*s,
+		[2] = z*x*k + y*s,  [5] = z*y*k - x*s,  [8] = z*z*k + c,
+	}};
+	$if $size == 3:
+	return r;
+	$else
+	Matrix{$size,$size, $Type} result @noinit;
+	matrix::identity_assign(&result);
+	matrix::@upsize(&r, &result);
+	return result;
+	$endif
+}
 
 <*
  @param left : "Left plane"

--- a/test/matrix.c3
+++ b/test/matrix.c3
@@ -1059,6 +1059,24 @@ fn void rotate_z()
 		"4x4 rotate_z not equal",
 	);
 }
+fn void rotate_axis()
+{
+	Matrix3x3 m3 = matrix::@identity(3);
+	m3.rotate_axis(math::PI / 2.0, vec3);
+	round(&m3);
+	@assert_print(m3,
+		(Matrix3x3){{ 0.037037, -0.999287, -0.007265, 0.925213, 0.037037, -0.377635, 0.377635, 0.007265, 0.925926 }},
+		"3x3 rotate_axis not equal",
+	);
+
+	Matrix4x4 m4 = matrix::@identity(4);
+	m4.rotate_axis(math::PI / 2.0, vec3);
+	round(&m4);
+	@assert_print(m4,
+		(Matrix4x4){{ 0.037037, -0.999287, -0.007265, 0.000000, 0.925213, 0.037037, -0.377635, 0.000000, 0.377635, 0.007265, 0.925926, 0.000000, 0.000000, 0.000000, 0.000000, 1.000000 }},
+		"4x4 rotate_axis not equal",
+	);
+}
 fn void transpose_assign()
 {
 	Matrix2x2 m2;

--- a/test/matrix_initializers.c3
+++ b/test/matrix_initializers.c3
@@ -39,19 +39,26 @@ fn void rotated_x()
 		(Matrix3x3){{ 1, 0, 0, 0, 0, 1, 0, -1, 0 }},
 		"rotated_x not equal",
 	);
-}                         
+}
 fn void rotated_y()
-{                         
+{
 	@assert_print(rounded(matrix::rotated_y(math::PI / 2)),
 		(Matrix3x3){{ 0, 0, -1, 0, 1, 0, 1, 0, 0 }},
 		"rotated_y not equal",
 	);
-}                         
+}
 fn void rotated_z()
-{                         
+{
 	@assert_print(rounded(matrix::rotated_z(math::PI / 2)),
 		(Matrix3x3){{ 0, 1, 0, -1, 0, 0, 0, 0, 1 }},
 		"rotated_z not equal",
+	);
+}
+fn void rotated_axis()
+{
+	@assert_print(rounded(matrix::rotated_axis(math::PI / 2, vec3)),
+		(Matrix3x3){{ 0.037037, -0.999287, -0.007265, 0.925213, 0.037037, -0.377635, 0.377635, 0.007265, 0.925926 }},
+		"rotated_axis not equal",
 	);
 }
 fn void ortho()


### PR DESCRIPTION
Added rotate_axis using Rodrigues' rotation formula.
Tried to add it to the standard library but was [told](https://github.com/c3lang/c3c/pull/2508) this will replace it sometime in the future.
Not sure if you want this added, so LMK.
Tried my best to match the style used in the rest of the library.