### PR TITLE
fix: translation matrix initializer

### DIFF
--- a/src/matrix_initializers.c3
+++ b/src/matrix_initializers.c3
@@ -23,7 +23,7 @@ macro translated(translate_vec)
 	const N = translate_vec.len;
 	Matrix{N+1,N+1, $typefrom($typeof(translate_vec).inner)} result
 		= matrix::@identity(N+1, $typefrom($typeof(translate_vec).inner));
-	foreach (i, component : translate_vec) result.m[i][^1] = component;
+	foreach (i, component : translate_vec) result.m[^1][i] = component;
 	return result;
 }
 <*


### PR DESCRIPTION
Hi! Thanks for the quick fix on the initialization!

I realized I misled you slightly in my previous issue (https://github.com/m0tholith/c3math/issues/7) regarding the layout, and the current implementation is still effectively broken for OpenGL usage.

While the matrix is now correctly initialized as an identity matrix, the translation components are currently being assigned to the last column (`m[i][^1]`), which corresponds to memory indices `3`, `7`, and `11`.
```
[  1  0  0  tx ]
[  0  1  0  ty ]
[  0  0  1  tz ]
[  0  0  0   1 ]
```
While this looks correct in standard mathematical notation, because the library uses row-major memory layout, these values end up transposed relative to what OpenGL expects (and inconsistent with the rest of the library).

For OpenGL (which expects translation at indices `12`, `13`, and `14`) and to maintain consistency with the existing `Matrix.translate` method (which uses `self.m[^1][i]`), the translation values need to be in the last row.

With this change, the memory layout will correctly place translation at the end of the array (indices `12-14`), matching the `Matrix.translate` behavior.